### PR TITLE
Add authenticate_admin

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,0 +1,3 @@
+class Admin::ApplicationController < ApplicationController
+  before_action :authenticate_admin!
+end

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -1,4 +1,4 @@
-class Admin::CategoriesController < ApplicationController
+class Admin::CategoriesController < Admin::ApplicationController
   before_action :set_category, only: %i[edit update]
   
   def index

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -1,4 +1,4 @@
-class Admin::CustomersController < ApplicationController
+class Admin::CustomersController < Admin::ApplicationController
   def index
     @customers = Customer.all
   end

--- a/app/controllers/admin/homes_controller.rb
+++ b/app/controllers/admin/homes_controller.rb
@@ -1,4 +1,4 @@
-class Admin::HomesController < ApplicationController
+class Admin::HomesController < Admin::ApplicationController
   def top
     # redirect_to admin_orders_path
   end

--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -1,4 +1,4 @@
-class Admin::OrderDetailsController < ApplicationController
+class Admin::OrderDetailsController < Admin::ApplicationController
   def update
     order_detail = OrderDetail.find(params[:id])
     order_detail.update(order_detail_params)

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,4 +1,4 @@
-class Admin::OrdersController < ApplicationController
+class Admin::OrdersController < Admin::ApplicationController
   before_action :set_order, only: %i[show update]
   
   def index

--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -1,4 +1,4 @@
-class Admin::ProductsController < ApplicationController
+class Admin::ProductsController < Admin::ApplicationController
   before_action :set_product, only: %i[show edit update]
   
   def index

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -19,11 +19,7 @@
           </button>
           <div class="collapse navbar-collapse flex-column" id="navbarNav">
             <ul class="navbar-nav ml-auto mb-2">
-              <% if customer_signed_in? %>
-                <%= render "layouts/customer_signed" %>
-              <% else %>
-                <%= render 'layouts/no_signed' %>
-              <% end %>
+              <%= render "layouts/admin_signed" %>
             </ul>
             <form class="d-flex ml-auto">
               <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">


### PR DESCRIPTION
以前、管理者と顧客のログイン状態でヘッダー内容を変更させるようコミットしましたが、一部修正してます。

### 変更前
layouts/application.html.erb内の条件分岐によって、ヘッダーの表示内容を変更していた。
・問題点
adminとしてログインしてる状態でpublic関連ページにアクセスするとヘッダーがおかしくなる。（逆も然り）

### 今回の変更
adminコントローラを使用する時だけ、別のレイアウトを使用する。

- ApplicationControllerクラスを継承するAdmin::ApplicationControllerクラスの作成
- controllers/adminファイル内にある各コントローラの継承元をAdmin::ApplicationControllerクラスに変更
- これにより、adminファイル内にある各コントローラはviews/layouts/admin/application.html.erbをレイアウトとして使用するようになる

またメリットとして、admin/application_controller.rb内にauthenticate_admin!を記述するだけで一括でログイン認証を行えるようになる。
