### PR TITLE
Add order new confirm view

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -61,6 +61,7 @@ class Public::OrdersController < ApplicationController
         @order_detail.quantity = cart_item.quantity
         @order_detail.making_status = 0
         @order_detail.save
+        # 最後の処理でカート内商品全削除
         if i == @cart_items.size - 1
           @cart_items.destroy_all
         end

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -37,6 +37,10 @@ class Public::OrdersController < ApplicationController
       @order.address_name = @shipping.name
     when "2" then
       @order = Order.new(order_params)
+      if @order.present?
+        redirect_to new_public_order_path
+      else
+      end
     end
 
   end

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -1,14 +1,10 @@
 <div class="container mt-4">
-    <div class="float-left cart-heading" style="width:230px;"><h5 class="text-center">ショッピングカート</h5></div>
-    <div class="float-right mb-3">
-      <%= link_to "カートを空にする", public_cart_items_path, method: :delete, class:"btn btn-danger" %>
+  <div class="d-flex justify-content-between mb-3">
+    <h5>
+      <span class="heading">ショッピングカート</span>
+    </h5>
+    <%= link_to "カートを空にする", public_cart_items_path, method: :delete, class:"btn btn-danger btn-sm" %>
   </div>
-  <!--<div class="d-flex justify-content-between mb-3">-->
-  <!--  <h5>-->
-  <!--    <span class="heading">ショッピングカート</span>-->
-  <!--  </h5>-->
-  <!--  <%= link_to "カートを空にする", public_cart_items_path, method: :delete, class:"btn btn-danger btn-sm" %>-->
-  <!--</div>-->
   <table class="table table-bordered cart-table">
     <thead>
       <th>商品名</th>

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -28,7 +28,7 @@
             <% end %>
           </td>
           <td class="align-middle">
-            <%= cart_item.subtotal %>
+            <%= cart_item.subtotal.to_s(:delimited) %>
           </td>
           <td class="align-middle text-center">
             <%= link_to "削除する", public_cart_item_path(cart_item.id), method: :delete, class:"btn btn-danger" %>
@@ -44,7 +44,7 @@
     <div class="offset-7 d-flex col-md-2">
       <table class="table table-bordered price-table">
         <th>合計金額</th>
-        <td><%= @total_price %></td>
+        <td><%= @total_price.to_s(:delimited) %></td>
       </table>
     </div>
   </div>

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -27,7 +27,7 @@
           <td class="align-middle"><%= cart_item.product.tax_in_price %></td>
           <td class="align-middle">
             <%= form_with(model: @cart_items, url:public_cart_item_path(cart_item.id), method: :patch, class:"form-inline") do |f| %>
-              <%= f.select :quantity, *[1..3], prompt: "#{cart_item.quantity}" %>
+              <%= f.select :quantity, *[1..10], selected: "#{cart_item.quantity}" %>
               <%= f.submit "変更", class:"btn btn-success ml-2" %>
             <% end %>
           </td>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -24,7 +24,7 @@
               <%= cart_item.quantity %>
             </td>
             <td class="align-middle">
-              <%= cart_item.subtotal %>
+              <%= cart_item.subtotal.to_s(:delimited) %>
             </td>
           </tr>
         <% end %>
@@ -37,11 +37,11 @@
       </tr>
       <tr>
         <td class="heading">商品合計</td>
-        <td><%= @total_price %></td>
+        <td><%= @total_price.to_s(:delimited) %></td>
       </tr>
       <tr>
         <td class="heading">請求金額</td>
-        <td><%= @amount_billed %></td>
+        <td><%= @amount_billed.to_s(:delimited) %></td>
       </tr>
     </table>
   </div>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -10,7 +10,7 @@
       <%= f.radio_button :payment_method, Order.payment_methods.key(0), class:"form-check-input" %>
       <%= f.label :payment_method, Order.payment_methods_i18n[:credit_card], class:"form-check-label" %>
     </div>
-    <div class="form-check ml-4">
+    <div class="ml-2 pl-1">
   　　<%= f.radio_button :payment_method, Order.payment_methods.key(1), class:"form-check-input" %>
       <%= f.label :payment_method, Order.payment_methods_i18n[:transfer], class:"form-check-label" %>
     </div>

--- a/app/views/public/products/show.html.erb
+++ b/app/views/public/products/show.html.erb
@@ -14,7 +14,7 @@
       </div>
       <%= form_with(model:@cart_item, url:public_cart_items_path, local: true ,method: :post, class:"form-inline") do |f| %>
         <%= f.hidden_field :product_id, value: @product.id %>
-        <%= f.select :quantity, *[1..3], prompt: "個数選択" %>
+        <%= f.select :quantity, *[1..10], prompt: "個数選択" %>
         <%= f.submit "カートに入れる", class:"btn btn-success ml-4" %>
       <% end %>
     </div>


### PR DESCRIPTION
新規注文の際、新しい住所を選択した時に入力がない場合は確認画面に飛ばないように修正。
私の環境だけ？かもしれませんが、ラジオボタンのずれを修正。
商品の個数選択の数を10個に修正。
カート内商品ページの個数表示の修正。
カート内商品のヘッダー部分の修正。
小計、請求金額の表示を区切られるように修正。
以上、確認の程、お願いいたします。
