### PR TITLE
Fix admin order status

### DIFF
--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -5,11 +5,10 @@ class Admin::OrderDetailsController < Admin::ApplicationController
 
     order_details = OrderDetail.where(order_id: params[:order_id])
     order = order_detail.order
-    if order_details.where(making_status: "making")
+    if order_details.where(making_status: "making").exists?
       order.status = "making"
       order.save
-    end
-    if order_details.where(making_status: "finish").count == order_details.count
+    elsif order_details.where(making_status: "finish").count == order_details.count
       order.status = "preparation_shipping"
       order.save
     end

--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -2,6 +2,18 @@ class Admin::OrderDetailsController < Admin::ApplicationController
   def update
     order_detail = OrderDetail.find(params[:id])
     order_detail.update(order_detail_params)
+
+    order_details = OrderDetail.where(order_id: params[:order_id])
+    order = order_detail.order
+    if order_details.where(making_status: "making")
+      order.status = "making"
+      order.save
+    end
+    if order_details.where(making_status: "finish").count == order_details.count
+      order.status = "preparation_shipping"
+      order.save
+    end
+
     redirect_to admin_order_path(params[:order_id])
     flash[:notice] = "ステータスを変更しました！"
   end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -10,6 +10,12 @@ class Admin::OrdersController < Admin::ApplicationController
 
   def update
     @order.update(order_params)
+    if @order.status == "confirm"
+      @order.order_details.each do |order_detail|
+        order_detail.making_status = "ready"
+        order_detail.save
+      end
+    end
     redirect_to admin_order_path(@order)
     flash[:notice] = "ステータスを変更しました！"
   end

--- a/app/helpers/admin/order_details_helper.rb
+++ b/app/helpers/admin/order_details_helper.rb
@@ -1,2 +1,3 @@
 module Admin::OrderDetailsHelper
+
 end

--- a/app/helpers/admin/order_details_helper.rb
+++ b/app/helpers/admin/order_details_helper.rb
@@ -1,3 +1,2 @@
 module Admin::OrderDetailsHelper
-
 end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -1,10 +1,10 @@
 class OrderDetail < ApplicationRecord
   belongs_to :product
   belongs_to :order
-  
+
   validates :product_id, :order_id, :quantity, :price, presence: true
 	validates :price, :quantity, numericality: { only_integer: true }
 
-  
+
   enum making_status: { default: 0, ready: 1, making: 2, finish: 3 }
 end


### PR DESCRIPTION
[テスト仕様書による修正]
管理者側の注文ステータス、制作ステータスの更新アクションを修正しました。

1. 注文ステータスが"入金確認"に変更　→　制作ステータスが"制作待ち"自動で更新。
2. 制作ステータスのどれか一つでも"製作中"になる　→　注文ステータスも"製作中"に自動で更新。
3. 全ての制作ステータスが"制作完了"になる　→　注文ステータスが"発送準備中"に自動で更新。

enumの命名がイマイチだった為、分かりづらいかもしれませんがご了承ください。。。