### PR TITLE
Fix page transition

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -13,13 +13,13 @@ class Public::CartItemsController < ApplicationController
     @cart_item = current_customer.cart_items.new(cart_item_params)
 
     cart_item = current_customer.cart_items.find_by(product_id: @cart_item.product_id)
-    
+
     # ↓↓佐藤追記（UnlessとReturnはすごい。動作内容個数がゼロの状態でカートに入れるを実行→エラーのデバック）
     unless @cart_item.quantity
       redirect_back(fallback_location: public_cart_items_path)
       return
     end
-    
+
     # ↓↓松井記述
     # カート内に同じ商品が存在したらtrue
     if cart_item.present?
@@ -29,11 +29,11 @@ class Public::CartItemsController < ApplicationController
         cart_item.save
         redirect_to public_cart_items_path
         flash[:notice] = "カートに商品を追加しました！"
-        
+
     elsif @cart_item.save
         redirect_to public_cart_items_path
         flash[:notice] = "カートに商品を追加しました！"
-        
+
     else
         render 'public/products/show'
     end

--- a/app/controllers/public/shippings_controller.rb
+++ b/app/controllers/public/shippings_controller.rb
@@ -1,15 +1,16 @@
 class Public::ShippingsController < ApplicationController
   before_action :set_shipping, only: %i[edit update destroy]
-  
+
   def set_shipping
     @shipping = Shipping.find(params[:id])
   end
-  
+
   def index
     @shippings = current_customer.shippings.all
     @shipping = Shipping.new
+    flash[:notice] =  "登録済みの配送先がありません。"
   end
-  
+
   def create
     @shipping = current_customer.shippings.new(shipping_params)
     if @shipping.save
@@ -23,7 +24,7 @@ class Public::ShippingsController < ApplicationController
 
   def edit
   end
-  
+
   def update
     if @shipping.update(shipping_params)
       redirect_to public_shippings_path
@@ -31,21 +32,21 @@ class Public::ShippingsController < ApplicationController
       render 'edit'
     end
   end
-  
+
   def destroy
     @shipping.destroy
     # @shippings = current_customer.shippings
     flash[:notice] =  "配送先を削除しました。"
     redirect_to public_shippings_path
   end
-  
-  
+
+
   private
-  
+
   def shipping_params
     params.require(:shipping).permit(:post_code, :address, :address_name)
   end
 end
 
-  
- 
+
+

--- a/app/views/admin/customers/order_index.html.erb
+++ b/app/views/admin/customers/order_index.html.erb
@@ -1,1 +1,8 @@
-<%= render 'admin/orders/index', orders: @orders %>
+<div class="container mt-3">
+  <div class="row">
+    <div class="col-10 mx-auto">
+      <h3 class="mb-3">注文履歴一覧</h3>
+      <%= render 'admin/orders/index', orders: @orders %>
+    </div>
+  </div>
+</div>

--- a/app/views/public/shippings/_ship.html.erb
+++ b/app/views/public/shippings/_ship.html.erb
@@ -33,8 +33,6 @@
             <% end %>
         </tbody>
     </table>
-<% end %>
-
-<% flash.each do |key, value| %>
-    <p id="<%= key %>"><%= value %></p>
+<% else %>
+  <p><%= flash[:notice] %></p>
 <% end %>


### PR DESCRIPTION
顧客のマイページで配送先一覧を見た際、
「ログインしました」というフラッシュメッセージが表示されていたので
登録済みの配送先がない時に限り、「登録済みの配送先はありません」と表示されるように修正しました。
表示させたいフラッシュメッセージの内容を汲み取れていなかったら、すみません。。。

また、顧客ごとの注文一覧ページのレイアウトを注文一覧ページと同じものに揃えました。

ご確認の程、よろしくお願いします。
